### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -21,7 +21,7 @@ jobs:
 
       # Runs the Super-Linter action
       - name: Run Super-Linter
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/superlinter.yml
+++ b/.github/workflows/superlinter.yml
@@ -1,4 +1,6 @@
 name: Super-Linter
+permissions:
+  contents: read
 
 # Run this workflow every time a new commit pushed to your repository
 on: push


### PR DESCRIPTION
Potential fix for [https://github.com/hrgupta/indian-scriptures/security/code-scanning/1](https://github.com/hrgupta/indian-scriptures/security/code-scanning/1)

The best way to fix the issue is to add a `permissions` block with `contents: read` either at the root of the workflow (to apply to all jobs) or specifically within the `super-lint` job. Since this workflow only has one job, both approaches are equivalent, but it is standard to add it at the root level unless job-specific requirements differ. No external libraries or further imports are needed; simply edit the `.github/workflows/superlinter.yml` file and add:

```yaml
permissions:
  contents: read
```

directly beneath the `name` field and before `on: push`. This ensures the workflow runs with the least privileged token suitable for the linter job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
