### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,6 +5,8 @@
 # For more information, see:
 # https://github.com/github/super-linter
 name: Lint Code Base
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hrgupta/indian-scriptures/security/code-scanning/2](https://github.com/hrgupta/indian-scriptures/security/code-scanning/2)

The best fix is to add a `permissions` block with the minimum necessary scopes directly under the workflow root (after the `name:` line, and before `on:`), so it applies to all jobs in the workflow unless otherwise specified. For this super-linter workflow, the required permissions are likely just `contents: read` because it needs to read code from the repository. If any job step requires more than `read`, you would include those as well, but based on the currently shown YAML, only `contents: read` is needed. Place the block with consistent YAML indentation, directly after the workflow `name:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
